### PR TITLE
Release version 2.0.4

### DIFF
--- a/GXModules/Mollie/Mollie/Admin/Classes/Controller/MollieModuleCenterModuleController.inc.php
+++ b/GXModules/Mollie/Mollie/Admin/Classes/Controller/MollieModuleCenterModuleController.inc.php
@@ -201,13 +201,33 @@ class MollieModuleCenterModuleController extends AbstractModuleCenterModuleContr
             $formattedStatus['id'] = $status->getId();
             try {
                 $formattedStatus['name'] = $status->getName(new LanguageCode(new StringType($_SESSION['language_code'])));
-            } catch (Exception $exception) {
-                $formattedStatus['name'] = $status->getName(new LanguageCode(new StringType('en')));
+            } catch (InvalidArgumentException $exception) {
+                $formattedStatus['name'] = $this->_getFallbackName($status);
             }
 
             $formattedStatuses[] = $formattedStatus;
         }
 
         return $formattedStatuses;
+    }
+
+    /**
+     * Returns status name in the first available language
+     *
+     * @param OrderStatus $status
+     *
+     * @return string|null
+     */
+    private function _getFallbackName(OrderStatus $status)
+    {
+        foreach (xtc_get_languages() as $language) {
+            try {
+                return $status->getName(new LanguageCode(new StringType($language['code'])));
+            } catch (Exception $exception) {
+                continue;
+            }
+        }
+
+        return '';
     }
 }

--- a/GXModules/Mollie/Mollie/Components/Services/Business/ConfigurationService.php
+++ b/GXModules/Mollie/Mollie/Components/Services/Business/ConfigurationService.php
@@ -12,7 +12,7 @@ use Mollie\Gambio\Utility\UrlProvider;
  */
 class ConfigurationService extends Configuration
 {
-    const MOLLIE_GAMBIO_VERSION = '2.0.3';
+    const MOLLIE_GAMBIO_VERSION = '2.0.4';
 
     /**
      * @inheritDoc

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ The payment methods are disabled by default in your account so you firstly need 
  6. **Check if there is any information in the logfile `Toolbox` » `Show logs`**
 
 # Release notes
+*2.0.4*
+- Bugfix: Use first available language for status name fallback instead of English.
+
 *2.0.3*
 - New feature: Implemented integration with Mollie Components.
 - New feature: Added iDeal, Giftcard, and KBC/CBC issuer selection in the checkout.


### PR DESCRIPTION
### Changed
- Bugfix: Use the first available language for status name fallback instead of English.